### PR TITLE
adding containers.podman to requirements.yml

### DIFF
--- a/ansible/roles/requirements.yml
+++ b/ansible/roles/requirements.yml
@@ -1,4 +1,11 @@
-- computate.computate_postgres
-- computate.computate_zookeeper
-- computate.computate_solr
-- computate.computate_project
+---
+roles:
+  # Install a role from Ansible Galaxy.
+  - computate.computate_postgres
+  - computate.computate_zookeeper
+  - computate.computate_solr
+  - computate.computate_project
+
+collections:
+  # Install a collection from Ansible Galaxy.
+  - containers.podman


### PR DESCRIPTION
I ran into 
```
TASK [include_role : computate.computate_postgres] *******************************************************************************************************************************************************************************************
ERROR! couldn't resolve module/action 'containers.podman.podman_network'. This often indicates a misspelling, missing collection, or incorrect module path.

The error appears to be in '/home/anbanerj/.ansible/roles/computate.computate_postgres/tasks/main.yml': line 147, column 3, but may
be elsewhere in the file depending on the exact syntax problem.

The offending line appears to be:

  when: POSTGRES_USE_PODMAN
- name: Create a podman network {{ POSTGRES_NETWORK }}
  ^ here
We could be wrong, but this one looks like it might be an issue with
missing quotes. Always quote template expression brackets when they
start a value. For instance:

    with_items:
      - {{ foo }}

Should be written as:

    with_items:
      - "{{ foo }}"

```

while running ```cd /usr/local/src/serratus-api && ansible-playbook install.yml -K``` . It resolved after I manually installed containers.podman role. So I think it needs to be in the requirements.yml file.